### PR TITLE
Added option for several values of metadata with OR logic

### DIFF
--- a/playback/tape_cassettes/s3/s3_tape_cassette.py
+++ b/playback/tape_cassettes/s3/s3_tape_cassette.py
@@ -259,6 +259,8 @@ class S3TapeCassette(TapeCassette):
                 if isinstance(v, str):
                     if not fnmatch(recorded_value, v):
                         return False
+                elif isinstance(v, list):
+                    return any(fnmatch(recorded_value, value) for value in v)
                 elif recorded_value != v:
                     return False
 

--- a/tests/test_cassettes/s3/test_s3_tape_cassette.py
+++ b/tests/test_cassettes/s3/test_s3_tape_cassette.py
@@ -268,6 +268,30 @@ class TestS3TapeCassette(unittest.TestCase):
                            list(self.cassette.iter_recording_ids(category='test_operation1',
                                                                  metadata={'property': 'val*'})))
 
+    def test_fetch_recording_ids_with_matching_metadata_value_not_set(self):
+        recording1 = self.cassette.create_new_recording('test_operation1')
+        recording1.add_metadata({'property': 'val11'})
+        self.cassette.save_recording(recording1)
+        recording2 = self.cassette.create_new_recording('test_operation1')
+        recording2.add_metadata({'property': 'val21'})
+        self.cassette.save_recording(recording2)
+        recording3 = self.cassette.create_new_recording('test_operation1')
+        recording3.add_metadata({'property': 'test'})
+        self.cassette.save_recording(recording3)
+        recording4 = self.cassette.create_new_recording('test_operation1')
+        self.cassette.save_recording(recording4)
+
+        assert_items_equal(self, [recording2.id, recording3.id],
+                           list(self.cassette.iter_recording_ids(category='test_operation1',
+                                                                 metadata={'property': ['val2*', 'test']})))
+
+        assert_items_equal(self, [recording1.id, recording2.id, recording3.id],
+                           list(self.cassette.iter_recording_ids(category='test_operation1',
+                                                                 metadata={'property': ['val*', 't*']})))
+        assert_items_equal(self, [],
+                           list(self.cassette.iter_recording_ids(category='test_operation1',
+                                                                 metadata={'property': ['try1', 'try2']})))
+
     def test_fetch_recording_ids_by_category_and_limit(self):
         recording1 = self.cassette.create_new_recording('test_operation1')
         self.cassette.save_recording(recording1)


### PR DESCRIPTION
Added option to make "OR" logic within the metadata:
e.g.:
```'metadata': { 'customer_name': ['google', 'facebook'] }``` will fetch the recording which customer_name is google or facebook