### PR TITLE
Metadata incomplete recording

### DIFF
--- a/playback/tape_cassettes/in_memory/in_memory_tape_cassette.py
+++ b/playback/tape_cassettes/in_memory/in_memory_tape_cassette.py
@@ -58,7 +58,7 @@ class InMemoryTapeCassette(TapeCassette):
 
             if metadata:
                 # Filter based on metadata if provided
-                if not all(metadata[key] == recording.get_metadata()[key] for key in metadata.keys()):
+                if not TapeCassette.match_against_recorded_metadata(metadata, recording.get_metadata()):
                     continue
 
             result.append(recording.id)

--- a/playback/tape_cassettes/s3/s3_tape_cassette.py
+++ b/playback/tape_cassettes/s3/s3_tape_cassette.py
@@ -6,7 +6,6 @@ from random import Random
 from zlib import compress, decompress
 import logging
 import uuid
-from fnmatch import fnmatch
 from datetime import datetime, timedelta
 import six
 from jsonpickle import encode, decode
@@ -251,20 +250,8 @@ class S3TapeCassette(TapeCassette):
         """
         def content_filter_func(recording_str):
             recording_metadata = decode(recording_str)
-            for k, v in metadata.items():  # pylint: disable=invalid-name
-                recorded_value = recording_metadata.get(k)
-                if recorded_value is None and v is not None:
-                    return False
+            return TapeCassette.match_against_recorded_metadata(metadata, recording_metadata)
 
-                if isinstance(v, str):
-                    if not fnmatch(recorded_value, v):
-                        return False
-                elif isinstance(v, list):
-                    return any(fnmatch(recorded_value, value) for value in v)
-                elif recorded_value != v:
-                    return False
-
-            return True
         return content_filter_func
 
     def iter_recording_ids(self, category, start_date=None, end_date=None, metadata=None, limit=None):

--- a/playback/tape_recorder.py
+++ b/playback/tape_recorder.py
@@ -37,6 +37,7 @@ class TapeRecorder(object):
     OPERATION_OUTPUT_ALIAS = '_tape_recorder_operation'
     OPERATION_CLASS = '_tape_recorder_operation_class'
     EXCEPTION_IN_OPERATION = '_tape_recorder_exception_in_operation'
+    INCOMPLETE_RECORDING = '_tape_recorder_incomplete_recording'
 
     def __init__(self, tape_cassette, random_seed=None):
         """
@@ -153,6 +154,12 @@ class TapeRecorder(object):
         """
         metadata[TapeRecorder.DURATION] = duration
         metadata[TapeRecorder.RECORDED_AT] = str(datetime.utcnow())
+        outputs = TapeRecorder._extract_recorded_output(recording)
+        # Check if the operation has completed by checking if we have operation output recorded, if not it means
+        # the operation method didn't complete and regular exception was not caught
+        # (this will happen when BaseException is raised such as KeyboardInterrupt, SystemExit)
+        incomplete = not any(TapeRecorder.OPERATION_OUTPUT_ALIAS in o.key for o in outputs)
+        metadata[TapeRecorder.INCOMPLETE_RECORDING] = incomplete
         if post_operation_metadata_extractor:
             try:
                 metadata.update(post_operation_metadata_extractor())

--- a/tests/test_cassettes/s3/test_s3_tape_cassette.py
+++ b/tests/test_cassettes/s3/test_s3_tape_cassette.py
@@ -292,6 +292,10 @@ class TestS3TapeCassette(unittest.TestCase):
                            list(self.cassette.iter_recording_ids(category='test_operation1',
                                                                  metadata={'property': ['try1', 'try2']})))
 
+        assert_items_equal(self, [recording2.id, recording3.id, recording4.id],
+                           list(self.cassette.iter_recording_ids(category='test_operation1',
+                                                                 metadata={'property': ['val2*', 'test', None]})))
+
     def test_fetch_recording_ids_by_category_and_limit(self):
         recording1 = self.cassette.create_new_recording('test_operation1')
         self.cassette.save_recording(recording1)

--- a/tests/test_tape_recorder.py
+++ b/tests/test_tape_recorder.py
@@ -184,8 +184,8 @@ class TestTapeRecorder(unittest.TestCase):
         recording = self.tape_cassette.get_recording(recording_id)
         # pickle encode decode doesn't reconstruct actuall class if this is an inner class
         operation_decoded = decode(encode(Operation, unpicklable=False))
-        self.assertDictContainsSubset({'type': operation_decoded, TapeRecorder.OPERATION_CLASS: operation_decoded},
-                                      recording.get_metadata())
+        self.assertLessEqual({'type': operation_decoded, TapeRecorder.OPERATION_CLASS: operation_decoded}.items(),
+                             recording.get_metadata().items())
         playback_result = self.tape_recorder.play(recording_id,
                                                   playback_function=lambda recording: Operation().execute())
         self._assert_playback_vs_recording(playback_result, result)
@@ -287,14 +287,16 @@ class TestTapeRecorder(unittest.TestCase):
         recording = self.tape_cassette.get_recording(recording_id)
         # pickle encode decode doesn't reconstruct actuall class if this is an inner class
         operation_decoded = decode(encode(Operation, unpicklable=False))
-        self.assertDictContainsSubset({TapeRecorder.OPERATION_CLASS: operation_decoded}, recording.get_metadata())
+        self.assertLessEqual({TapeRecorder.OPERATION_CLASS: operation_decoded}.items(),
+                             recording.get_metadata().items())
 
         self.assertEqual(5, instance.class_execute())
 
         recording_id = self.tape_cassette.get_last_recording_id()
         recording = self.tape_cassette.get_recording(recording_id)
         # Inner classes are not unpicklable back to class upon decode
-        self.assertDictContainsSubset({TapeRecorder.OPERATION_CLASS: operation_decoded}, recording.get_metadata())
+        self.assertLessEqual({TapeRecorder.OPERATION_CLASS: operation_decoded}.items(),
+                             recording.get_metadata().items())
 
     def test_drop_recording_direct_api_call(self):
         local_tape_recorder = self.tape_recorder
@@ -514,8 +516,8 @@ class TestTapeRecorder(unittest.TestCase):
         self.assertEqual(len(playback_result.recorded_outputs), len(playback_result.playback_outputs))
         self.assertGreater(playback_result.playback_duration, 0)
         self.assertGreater(playback_result.recorded_duration, 0)
-        self.assertDictContainsSubset({TapeRecorder.EXCEPTION_IN_OPERATION: True},
-                                      playback_result.original_recording.get_metadata())
+        self.assertLessEqual({TapeRecorder.EXCEPTION_IN_OPERATION: True}.items(),
+                             playback_result.original_recording.get_metadata().items())
 
     def test_record_and_playback_basic_operation_no_parameters_raise_unserializable_error(self):
 
@@ -544,8 +546,8 @@ class TestTapeRecorder(unittest.TestCase):
         self.assertEqual(len(playback_result.recorded_outputs), len(playback_result.playback_outputs))
         self.assertGreater(playback_result.playback_duration, 0)
         self.assertGreater(playback_result.recorded_duration, 0)
-        self.assertDictContainsSubset({TapeRecorder.EXCEPTION_IN_OPERATION: True},
-                                      playback_result.original_recording.get_metadata())
+        self.assertLessEqual({TapeRecorder.EXCEPTION_IN_OPERATION: True}.items(),
+                             playback_result.original_recording.get_metadata().items())
 
     def test_record_and_playback_basic_operation_data_interception_no_arguments_raise_exception(self):
         class Operation(object):


### PR DESCRIPTION
Add to recording metadata information if the recording is incomplete, which means uncaught BaseException occurred during the operation.