### PR TITLE
Install future as dev dependency since it is needed for moto

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setuptools.setup(
         'Werkzeug==0.16.1',
         'Flask==1.1.2',
         'flask-restplus==0.13.0',
+        'future==0.18.2',
         'pylint==2.6.0; python_version > "3.0"',
         'pylint-junit==0.3.2; python_version > "3.0"',
         'flake8==3.8.4; python_version > "3.0"',


### PR DESCRIPTION
This error was not been caught because we are using shared python virtual environments in our machines.

Fixes the import errors when installing `moto`.