### PR TITLE
Add support for operator in metadata filtering

### DIFF
--- a/playback/tape_cassette.py
+++ b/playback/tape_cassette.py
@@ -143,6 +143,9 @@ class TapeCassette(object):
         if isinstance(match_value, list):
             return any(TapeCassette._match_metadata_value(value, recorded_value) for value in match_value)
 
+        if isinstance(match_value, dict) and 'operator' in match_value and 'value' in match_value:
+            return TapeCassette._operator_filter(recorded_value, match_value)
+
         if recorded_value is None and match_value is not None:
             return False
 
@@ -150,6 +153,25 @@ class TapeCassette(object):
             return fnmatch(recorded_value, match_value)
 
         return recorded_value == match_value
+
+    @staticmethod
+    def _operator_filter(recorded_value, metadata_value):
+        """
+        Check if this is an operator metadata filter and its value is in range
+        """
+        result = False
+        if metadata_value['operator'] == '=':
+            result = recorded_value == metadata_value['value']
+        if metadata_value['operator'] == '<':
+            result = recorded_value < metadata_value['value']
+        if metadata_value['operator'] == '<=':
+            result = recorded_value <= metadata_value['value']
+        if metadata_value['operator'] == '>':
+            result = recorded_value > metadata_value['value']
+        if metadata_value['operator'] == '>=':
+            result = recorded_value >= metadata_value['value']
+
+        return result
 
     @abstractmethod
     def extract_recording_category(self, recording_id):

--- a/tests/test_tape_cassette.py
+++ b/tests/test_tape_cassette.py
@@ -1,0 +1,105 @@
+# p3ready
+from __future__ import absolute_import
+
+import unittest
+
+from playback.tape_cassette import TapeCassette
+
+
+class TestTapeCassette(unittest.TestCase):
+
+    def test_metadata_content_filter_by_number_value(self):
+        recording_metadata = {'key1': 5, 'key2': "bla"}
+        filter_metadata = {'key1': 5}
+        self.assertTrue(TapeCassette.match_against_recorded_metadata(filter_metadata, recording_metadata))
+
+    def test_metadata_content_filter_by_number_value_not_found(self):
+        recording_metadata = {'key1': 5, 'key2': "bla"}
+        filter_metadata = {'key1': 8}
+        self.assertFalse(TapeCassette.match_against_recorded_metadata(filter_metadata, recording_metadata))
+
+    def test_metadata_content_filter_by_string_value(self):
+        recording_metadata = {'key1': 5, 'key2': "bla"}
+        filter_metadata = {'key2': "bla"}
+        self.assertTrue(TapeCassette.match_against_recorded_metadata(filter_metadata, recording_metadata))
+
+    def test_metadata_content_filter_by_string_value_not_found(self):
+        recording_metadata = {'key1': 5, 'key2': "bla"}
+        filter_metadata = {'key2': "bla1"}
+        self.assertFalse(TapeCassette.match_against_recorded_metadata(filter_metadata, recording_metadata))
+
+    def test_metadata_content_filter_by_list_value(self):
+        recording_metadata = {'key1': 5, 'key2': "bla"}
+        filter_metadata = {'key2': ["bla", "bla2"]}
+        self.assertTrue(TapeCassette.match_against_recorded_metadata(filter_metadata, recording_metadata))
+
+        recording_metadata = {'key1': 5, 'key2': "bla2"}
+        filter_metadata = {'key2': ["bla", "bla2"]}
+        self.assertTrue(TapeCassette.match_against_recorded_metadata(filter_metadata, recording_metadata))
+
+    def test_metadata_content_filter_by_list_operator_object_value(self):
+        recording_metadata = {'key1': 5, 'key2': "bla"}
+        filter_metadata = {'key2': ["bla4", "bla5", {'operator': '=', 'value': "bla"}]}
+        self.assertTrue(TapeCassette.match_against_recorded_metadata(filter_metadata, recording_metadata))
+
+    def test_metadata_content_filter_by_list_value_not_found(self):
+        recording_metadata = {'key1': 5, 'key2': "bla"}
+        filter_metadata = {'key2': ["bla1", "bla2"]}
+        self.assertFalse(TapeCassette.match_against_recorded_metadata(filter_metadata, recording_metadata))
+
+        recording_metadata = {'key1': 5, 'key2': "bla2"}
+        filter_metadata = {'key2': ["bla", "bla3"]}
+        self.assertFalse(TapeCassette.match_against_recorded_metadata(filter_metadata, recording_metadata))
+
+    def test_metadata_content_filter_by_object_value(self):
+        recording_metadata = {'key1': 5, 'key2': "bla", 'obj': {'key1': 6, 'key2': "bla"}}
+        filter_metadata = {'obj': {'key1': 6, 'key2': "bla"}}
+        self.assertTrue(TapeCassette.match_against_recorded_metadata(filter_metadata, recording_metadata))
+
+        filter_metadata = {'obj': {'key1': 6, 'key2': "bla1"}}
+        self.assertFalse(TapeCassette.match_against_recorded_metadata(filter_metadata, recording_metadata))
+
+    def test_metadata_content_filter_by_operator_object_value_equal(self):
+        recording_metadata = {'key1': 5, 'key2': "bla", 'duration': 5}
+        filter_metadata = {'duration': {'operator': '=', 'value': 5}}
+        self.assertTrue(TapeCassette.match_against_recorded_metadata(filter_metadata, recording_metadata))
+
+        recording_metadata = {'key1': 5, 'key2': "bla", 'duration': 6}
+        filter_metadata = {'duration': {'operator': '=', 'value': 5}}
+        self.assertFalse(TapeCassette.match_against_recorded_metadata(filter_metadata, recording_metadata))
+
+    def test_metadata_content_filter_by_operator_object_value_less(self):
+        recording_metadata = {'key1': 5, 'key2': "bla", 'duration': 4.9}
+        filter_metadata = {'duration': {'operator': '<', 'value': 5}}
+        self.assertTrue(TapeCassette.match_against_recorded_metadata(filter_metadata, recording_metadata))
+
+        recording_metadata = {'key1': 5, 'key2': "bla", 'duration': 5}
+        filter_metadata = {'duration': {'operator': '<', 'value': 5}}
+        self.assertFalse(TapeCassette.match_against_recorded_metadata(filter_metadata, recording_metadata))
+
+    def test_metadata_content_filter_by_operator_object_value_less_equal(self):
+        recording_metadata = {'key1': 5, 'key2': "bla", 'duration': 5}
+        filter_metadata = {'duration': {'operator': '<=', 'value': 5}}
+        self.assertTrue(TapeCassette.match_against_recorded_metadata(filter_metadata, recording_metadata))
+
+        recording_metadata = {'key1': 5, 'key2': "bla", 'duration': 5.1}
+        filter_metadata = {'duration': {'operator': '<=', 'value': 5}}
+        self.assertFalse(TapeCassette.match_against_recorded_metadata(filter_metadata, recording_metadata))
+
+    def test_metadata_content_filter_by_operator_object_value_greater(self):
+        recording_metadata = {'key1': 5, 'key2': "bla", 'duration': 5.1}
+        filter_metadata = {'duration': {'operator': '>', 'value': 5}}
+        self.assertTrue(TapeCassette.match_against_recorded_metadata(filter_metadata, recording_metadata))
+
+        recording_metadata = {'key1': 5, 'key2': "bla", 'duration': 5}
+        filter_metadata = {'duration': {'operator': '>', 'value': 5}}
+        self.assertFalse(TapeCassette.match_against_recorded_metadata(filter_metadata, recording_metadata))
+
+    def test_metadata_content_filter_by_operator_object_value_greater_equal(self):
+        recording_metadata = {'key1': 5, 'key2': "bla", 'duration': 5.1}
+        filter_metadata = {'duration': {'operator': '>=', 'value': 5}}
+        self.assertTrue(TapeCassette.match_against_recorded_metadata(filter_metadata, recording_metadata))
+
+        recording_metadata = {'key1': 5, 'key2': "bla", 'duration': 4.9}
+        filter_metadata = {'duration': {'operator': '>=', 'value': 5}}
+        self.assertFalse(TapeCassette.match_against_recorded_metadata(filter_metadata, recording_metadata))


### PR DESCRIPTION
Add support to filter recording with and operator expression in the metadata
Supported operators:
- `=`
- `<`
- `<=`
- `>`
- `>=`

Example: {'duration': {'operator': '>=', 'value': 5}}