### PR TITLE
Os 43862 recording retrieval slow

### DIFF
--- a/playback/studio/recordings_lookup.py
+++ b/playback/studio/recordings_lookup.py
@@ -1,5 +1,3 @@
-from random import shuffle
-
 from playback.tape_recorder import TapeRecorder
 
 
@@ -45,11 +43,7 @@ def find_matching_recording_ids(tape_recorder, category, lookup_properties):
     recording_ids = tape_recorder.tape_cassette.iter_recording_ids(
             category, start_date=lookup_properties.start_date, end_date=lookup_properties.end_date,
             metadata=metadata,
-            limit=(None if lookup_properties.random_sample else lookup_properties.limit))
-
-    if lookup_properties.random_sample:
-        recording_ids = list(recording_ids)
-        shuffle(recording_ids)
-        recording_ids = iter(recording_ids[:lookup_properties.limit])
+            limit=lookup_properties.limit,
+            random_results=lookup_properties.random_sample)
 
     return recording_ids

--- a/playback/tape_cassette.py
+++ b/playback/tape_cassette.py
@@ -77,7 +77,8 @@ class TapeCassette(object):
         pass
 
     @abstractmethod
-    def iter_recording_ids(self, category, start_date=None, end_date=None, metadata=None, limit=None):
+    def iter_recording_ids(self, category, start_date=None, end_date=None, metadata=None, limit=None,
+                           random_results=False):
         """
         Creates an iterator of recording ids matching the given search parameters
         :param category: Recordings category
@@ -90,6 +91,8 @@ class TapeCassette(object):
         :type metadata: dict
         :param limit: Optional limit on number of ids to fetch
         :type limit: int
+        :param random_results: True to return result in random order
+        :type random_results: bool
         :return: Iterator of recording ids matching the given parameters
         :rtype: collections.Iterator[str]
         """

--- a/playback/tape_cassettes/asynchronous/async_record_only_tape_cassette.py
+++ b/playback/tape_cassettes/asynchronous/async_record_only_tape_cassette.py
@@ -58,7 +58,8 @@ class AsyncRecordOnlyTapeCassette(TapeCassette):
     def get_recording(self, recording_id):
         raise TypeError("AsyncTapeCassette should only be used for recording, not playback")
 
-    def iter_recording_ids(self, category, start_date=None, end_date=None, metadata=None, limit=None):
+    def iter_recording_ids(self, category, start_date=None, end_date=None, metadata=None, limit=None,
+                           random_results=False):
         raise TypeError("AsyncTapeCassette should only be used for recording, not playback")
 
     def extract_recording_category(self, recording_id):

--- a/playback/tape_cassettes/file_based/file_based_tape_cassette.py
+++ b/playback/tape_cassettes/file_based/file_based_tape_cassette.py
@@ -66,7 +66,8 @@ class FileBasedTapeCassette(TapeCassette):
         with io.open(self._get_recording_file_path(recording.id), "w", encoding="utf-8") as f:
             f.write(encoded)
 
-    def iter_recording_ids(self, category, start_date=None, end_date=None, metadata=None, limit=None):
+    def iter_recording_ids(self, category, start_date=None, end_date=None, metadata=None, limit=None,
+                           random_results=False):
         """
         Creates an iterator of recording ids matching the given search parameters
         :param category: Recordings category
@@ -79,6 +80,8 @@ class FileBasedTapeCassette(TapeCassette):
         :type metadata: dict
         :param limit: Optional limit on number of ids to fetch
         :type limit: int
+        :param random_results: True to return result in random order
+        :type random_results: bool
         :return: Iterator of recording ids matching the given parameters
         :rtype: collections.Iterator[str]
         """

--- a/playback/tape_cassettes/in_memory/in_memory_tape_cassette.py
+++ b/playback/tape_cassettes/in_memory/in_memory_tape_cassette.py
@@ -1,5 +1,7 @@
 import uuid
 from collections import OrderedDict
+from random import shuffle
+
 from jsonpickle import encode, decode
 
 from playback.recordings.memory.memory_recording import MemoryRecording
@@ -49,7 +51,8 @@ class InMemoryTapeCassette(TapeCassette):
         return MemoryRecording(_id=deserialized_form.id, recording_data=deserialized_form.recording_data,
                                recording_metadata=deserialized_form.recording_metadata)
 
-    def iter_recording_ids(self, category, start_date=None, end_date=None, metadata=None, limit=None):
+    def iter_recording_ids(self, category, start_date=None, end_date=None, metadata=None, limit=None,
+                           random_results=False):
         result = []
         for serialized_recording in self._recordings.values():
             recording = decode(serialized_recording)
@@ -65,6 +68,9 @@ class InMemoryTapeCassette(TapeCassette):
 
         if limit:
             result = result[:limit]
+
+        if random_results:
+            shuffle(result)
 
         return iter(result)
 

--- a/playback/tape_cassettes/s3/s3_tape_cassette.py
+++ b/playback/tape_cassettes/s3/s3_tape_cassette.py
@@ -8,6 +8,7 @@ import logging
 import uuid
 from datetime import datetime, timedelta
 import six
+import json
 from jsonpickle import encode, decode
 from parse import compile  # pylint: disable=redefined-builtin
 
@@ -249,7 +250,7 @@ class S3TapeCassette(TapeCassette):
         :rtype: function
         """
         def content_filter_func(recording_str):
-            recording_metadata = decode(recording_str)
+            recording_metadata = json.loads(recording_str)
             return TapeCassette.match_against_recorded_metadata(metadata, recording_metadata)
 
         return content_filter_func

--- a/tests/studio/test_equalizer.py
+++ b/tests/studio/test_equalizer.py
@@ -130,8 +130,8 @@ class TestEqualizer(unittest.TestCase):
         self.assertEqual(8, comparison[1].actual)
         self.assertEqual(500, comparison[2].actual)
 
-        mock.assert_called_with(Operation.__name__, start_date=start_date, end_date=end_date, limit=None, metadata={
-            TapeRecorder.INCOMPLETE_RECORDING: [False, None]})
+        mock.assert_called_with(Operation.__name__, start_date=start_date, end_date=end_date, limit=None,
+                                random_results=False, metadata={TapeRecorder.INCOMPLETE_RECORDING: [False, None]})
         self.assertGreaterEqual(comparison[0].playback.playback_duration, 0)
         self.assertGreaterEqual(comparison[0].playback.recorded_duration, 0)
 
@@ -218,7 +218,8 @@ class TestEqualizer(unittest.TestCase):
         self.assertEqual(8, comparison[1].actual)
         self.assertEqual(500, comparison[2].actual)
 
-        mock.assert_called_with(Operation.__name__, start_date=start_date, end_date=end_date, limit=None, metadata=None)
+        mock.assert_called_with(Operation.__name__, start_date=start_date, end_date=end_date, limit=None,
+                                random_results=False, metadata=None)
         self.assertGreaterEqual(comparison[0].playback.playback_duration, 0)
         self.assertGreaterEqual(comparison[0].playback.recorded_duration, 0)
 
@@ -541,7 +542,7 @@ class TestEqualizer(unittest.TestCase):
         self.assertEqual(1, len(comparison))
         self.assertEqual(EqualityStatus.Equal, comparison[0].comparator_status.equality_status)
 
-        mock.assert_called_with(Operation.__name__, start_date=start_date, end_date=None,
+        mock.assert_called_with(Operation.__name__, start_date=start_date, end_date=None, random_results=False,
                                 limit=1, metadata={'meta': 'b', TapeRecorder.INCOMPLETE_RECORDING: [False, None]})
         self.assertEqual(4, comparison[0].expected)
         self.assertEqual(4, comparison[0].actual)


### PR DESCRIPTION
## First commit:
Use json instead of decode to prevent class importing

## Second commit:
Use `random_sample` arg to truly return random order, if it set to false it will return the same list in most cases + always limit the number of recording we fetch