### PR TITLE
Add an option to define fallback aliases for input interceptions

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -9,7 +9,7 @@ disable=missing-module-docstring,useless-object-inheritance,logging-format-inter
 [BASIC]
 good-names=id,ex,f
 [DESIGN]
-max-args=8
+max-args=9
 max-attributes=12
 [SIMILARITIES]
 

--- a/playback/utils/is_iterable.py
+++ b/playback/utils/is_iterable.py
@@ -1,0 +1,12 @@
+def is_iterable(thing):
+    """
+    Checks if the parameter is iterable.
+    :param thing:
+    :return:
+    """
+    try:
+        iter(thing)
+    except TypeError:
+        return False
+
+    return True

--- a/playback/utils/pickle_copy.py
+++ b/playback/utils/pickle_copy.py
@@ -1,0 +1,10 @@
+from jsonpickle import encode, decode
+
+
+def pickle_copy(value):
+    """ copies any object (deeply) by pickly encoding/decoding it
+    :type value: any
+    :param value: the value you to be copied
+    :rtype: any
+    """
+    return decode(encode(value, unpicklable=True))


### PR DESCRIPTION
Defining fallback aliases may be very useful when we want to change the primary alias (for example, to give it a better name or add a parameter). Still, we also don't want to break old recordings. These aliases will be used to get data from recording if the primary interception key is missing.