### PR TITLE
Copy data retrieved from recording upon playback to prevent accidenal modifications by the calling code

### DIFF
--- a/playback/recording.py
+++ b/playback/recording.py
@@ -38,6 +38,9 @@ class Recording(object):
     @abstractmethod
     def get_data(self, key):
         """
+        Should always return a fresh copy of the data event when called multiple times with the same key,
+        to prevent modifications of the recording by the calling code. These modifications can lead to differences in
+        outputs that are not expected and will yield false positives.
         :param key: Data key
         :type key: basestring
         :return: Recorded data under given key

--- a/playback/recordings/memory/memory_recording.py
+++ b/playback/recordings/memory/memory_recording.py
@@ -1,5 +1,6 @@
 from playback.exceptions import RecordingKeyError
 from playback.recording import Recording
+from playback.utils.pickle_copy import pickle_copy
 
 
 class MemoryRecording(Recording):
@@ -37,7 +38,10 @@ class MemoryRecording(Recording):
         if key not in self.recording_data:
             raise RecordingKeyError(u'Key \'{}\' not found in recording'.format(key).encode("utf-8"))
 
-        return self.recording_data.get(key)
+        # The contract of the recording requires the implementation to always return a fresh copy of the data.
+        # It prevents in place modifications that may be done by the calling code to influence the outcome
+        # of the recording playback. That's why we copy here.
+        return pickle_copy(self.recording_data.get(key))
 
     def get_all_keys(self):
         """


### PR DESCRIPTION
The problem we are trying to solve here is that sometimes one recorded input is accessed multiple times by the calling code (for example, when the same data is fetched from the DB multiple times). If the data is modified in place by the calling code, it affects what data will be returned from the consecutive retrievals of the particular input during playback. This may cause differences in yielded results (see the test case). To prevent that, we can deep copy the data when fetching from the recording (as we also do when intercepting the input during recording).