### PR TITLE
Use thread-local storage to make interception logic thread-safe

### DIFF
--- a/playback/tape_recorder.py
+++ b/playback/tape_recorder.py
@@ -51,7 +51,6 @@ class TapeRecorder(object):
         self._random = Random(random_seed)
         self._force_sample = False
         self._thread_locals = threading.local()
-        self._currently_in_interception = False
 
     @contextmanager
     def start_recording(self, category, metadata, post_operation_metadata_extractor=None):

--- a/playback/tape_recorder.py
+++ b/playback/tape_recorder.py
@@ -1,11 +1,13 @@
 # pylint: disable=not-context-manager
 # pylint: disable=broad-except
+# pylint: disable=too-many-lines
 from __future__ import absolute_import
 from collections import namedtuple, Counter
 import logging
 from random import Random
 from datetime import datetime
 from time import time
+import threading
 from jsonpickle import encode
 from decorator import contextmanager
 
@@ -48,6 +50,7 @@ class TapeRecorder(object):
         self._classes_recording_params = {}
         self._random = Random(random_seed)
         self._force_sample = False
+        self._thread_locals = threading.local()
         self._currently_in_interception = False
 
     @contextmanager
@@ -270,6 +273,25 @@ class TapeRecorder(object):
         if self.in_playback_mode:
             return self._playback_recording.id
         return None
+
+    @property
+    def _currently_in_interception(self):
+        """
+        :return: Is currently in interception
+        :rtype: bool
+        """
+        if not hasattr(self._thread_locals, 'currently_in_interception'):
+            return False
+
+        return self._thread_locals.currently_in_interception
+
+    @_currently_in_interception.setter
+    def _currently_in_interception(self, value):
+        """
+        :param value: Is currently in interception
+        :type value: bool
+        """
+        self._thread_locals.currently_in_interception = value
 
     @property
     def _should_intercept(self):


### PR DESCRIPTION
This PR fixes a problem with `_enter_interception_context` context manager in programs using multiple threads. This context manager is modifying a global variable that will only allow interceptions in one thread. I used thread-local storage to make it thread-safe and treat interceptions in multiple threads independently.