### PR TITLE
Add a method to the Recording which allows getting the underlying rec…

### DIFF
--- a/playback/recording.py
+++ b/playback/recording.py
@@ -50,6 +50,20 @@ class Recording(object):
         pass
 
     @abstractmethod
+    def get_data_direct(self, key):
+        """
+        Get the data directly from the recording with necessarily copying it, this should be used with care for
+        performance reasons, mainly to be accessed during the recording stage as it can return the underlying saved
+        data and not a copy
+        :param key: Data key
+        :type key: basestring
+        :return: Recorded data under given key
+        :rtype: Any
+        :raise: playback.exceptions.RecordingKeyError
+        """
+        pass
+
+    @abstractmethod
     def get_all_keys(self):
         """
         :return: All recorded keys

--- a/playback/recordings/memory/memory_recording.py
+++ b/playback/recordings/memory/memory_recording.py
@@ -35,13 +35,22 @@ class MemoryRecording(Recording):
         :return: Recorded data under given key
         :rtype: Any
         """
-        if key not in self.recording_data:
-            raise RecordingKeyError(u'Key \'{}\' not found in recording'.format(key).encode("utf-8"))
-
         # The contract of the recording requires the implementation to always return a fresh copy of the data.
         # It prevents in place modifications that may be done by the calling code to influence the outcome
         # of the recording playback. That's why we copy here.
-        return pickle_copy(self.recording_data.get(key))
+        return pickle_copy(self.get_data_direct(key))
+
+    def get_data_direct(self, key):
+        """
+        :param key: Data key
+        :type key: basestring
+        :return: Recorded data under given key
+        :rtype: Any
+        """
+        if key not in self.recording_data:
+            raise RecordingKeyError(u'Key \'{}\' not found in recording'.format(key).encode("utf-8"))
+
+        return self.recording_data.get(key)
 
     def get_all_keys(self):
         """

--- a/playback/tape_recorder.py
+++ b/playback/tape_recorder.py
@@ -148,7 +148,7 @@ class TapeRecorder(object):
         """
         metadata[TapeRecorder.DURATION] = duration
         metadata[TapeRecorder.RECORDED_AT] = str(datetime.utcnow())
-        outputs = TapeRecorder._extract_recorded_output(recording)
+        outputs = TapeRecorder._extract_recorded_output(recording, direct_access=True)
         # Check if the operation has completed by checking if we have operation output recorded, if not it means
         # the operation method didn't complete and regular exception was not caught
         # (this will happen when BaseException is raised such as KeyboardInterrupt, SystemExit)
@@ -903,16 +903,19 @@ class TapeRecorder(object):
         return Playback(playback_outputs, playback_duration, recorded_outputs, recorded_duration, recording)
 
     @staticmethod
-    def _extract_recorded_output(recording):
+    def _extract_recorded_output(recording, direct_access=False):
         """
         :param recording:
         :type recording: playback.recording.Recording
-        :return:
-        :rtype:
+        :param direct_access: Should the output be extracted using direct access
+        :type direct_access: bool
+        :return: List of output objects
+        :rtype: list of Output
         """
         all_output_keys = [key for key in recording.get_all_keys() if key.startswith('output:') and
                            not key.endswith('result')]
-        return [Output(key, recording.get_data(key)) for key in all_output_keys]
+        return [Output(key, (recording.get_data if not direct_access else recording.get_data_direct)(key))
+                for key in all_output_keys]
 
     @staticmethod
     def _input_interception_key(alias, capture_args, static_function, *args, **kwargs):


### PR DESCRIPTION
Add a method to the Recording which allows getting the underlying recorded data without copying it. This provides fast access which can be used during the actual recording to avoid adding overhead while operation is being recorded, use this direct access in the metadata assignment stage when the recording stage is ending