### PR TITLE
Fix binary data handling in cached S3 facade for Python 3 compatibility

### DIFF
--- a/playback/tape_cassettes/cached/cached_facade.py
+++ b/playback/tape_cassettes/cached/cached_facade.py
@@ -1,6 +1,7 @@
 import os
 import logging
 from tempfile import gettempdir
+from six import PY2
 
 from playback.tape_cassettes.s3.s3_basic_facade import S3BasicFacade
 from playback.tape_cassettes.s3.s3_tape_cassette import S3TapeCassette
@@ -37,7 +38,8 @@ class CachedS3BasicFacade(S3BasicFacade):
         local_key_path = os.path.join(self.cache_path, key_file_name)
         found_locally = False
         if os.path.exists(local_key_path):
-            with open(local_key_path, "r") as fid:
+            mode = "r" if PY2 else "rb"
+            with open(local_key_path, mode) as fid:
                 raw_data = fid.read()
                 logger.info("File {} was found in local cache {}".format(key_file_name, local_key_path))
                 found_locally = True
@@ -64,7 +66,8 @@ class CachedS3BasicFacade(S3BasicFacade):
         :param raw_data: raw data to be cached
         :type raw_data: str
         """
-        with open(local_full_key_path, "w") as fid:
+        mode = "w" if PY2 else "wb"
+        with open(local_full_key_path, mode) as fid:
             fid.write(raw_data)
         logger.info("Caching in {} succeeded".format(local_full_key_path))
 

--- a/tests/resources/cached_recordings/some_random_recording_id_py3
+++ b/tests/resources/cached_recordings/some_random_recording_id_py3
@@ -1,0 +1,1 @@
+Some raw data


### PR DESCRIPTION
## Summary
- Fixed binary data handling in `CachedS3BasicFacade` to use appropriate file modes for Python 2/3 compatibility
- The cached facade was incorrectly using text mode ('r'/'w') for compressed binary data, causing `TypeError: a bytes-like object is required, not str` when decompressing in Python 3
- Updated version from 0.3.24 to 0.3.25

## Test plan
- [x] Fixed failing `TestCachedS3TapeCassette::test_cached_s3_tape_cassette` test
- [x] Verified binary data is correctly cached and retrieved in both Python 2 and Python 3
- [x] All cached S3 tape cassette tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)