### PR TITLE
OS-74611 Add `SQLiteRecording` to improve memory consumption

### DIFF
--- a/playback/recording.py
+++ b/playback/recording.py
@@ -13,6 +13,46 @@ class Recording(object):
         self.id = _id or uuid.uuid1().hex
         self._closed = False
 
+    @staticmethod
+    @abstractmethod
+    def new(_id=None):
+        """
+        Creates a new recording instance.
+
+        :param _id: Optional ID for the recording. If not provided, a new UUID will be generated.
+        :type _id: str
+        :return: A new Recording instance.
+        :rtype: Recording
+        """
+
+    @staticmethod
+    @abstractmethod
+    def from_buffered_reader(recording_id, buffered_reader, recording_metadata):
+        """
+        Fetches, decompresses, decodes, and prepares a recording from a buffered reader.
+
+        :param recording_id: The ID of the recording to fetch.
+        :type recording_id: str
+        :param buffered_reader: A buffered reader instance to read the compressed recording data.
+        :type buffered_reader: BufferedReader
+        :param recording_metadata: Metadata that could optionally override or append to the extracted
+            metadata from the recording.
+        :type recording_metadata: dict
+        :return: A new MemoryRecording instance containing the fetched recording and its metadata.
+        :rtype: MemoryRecording
+        """
+        pass
+
+    @abstractmethod
+    def as_buffered_reader(self):
+        """
+        Gives access to the recording data as a BufferedReader.
+
+        :returns: A buffered reader instance for reading the recording data.
+        :rtype: BufferedReader
+        """
+        pass
+
     @abstractmethod
     def _set_data(self, key, value):
         """

--- a/playback/recordings/factory.py
+++ b/playback/recordings/factory.py
@@ -1,0 +1,22 @@
+from typing import Type
+
+from playback.recording import Recording
+from playback.recordings.memory.memory_recording import MemoryRecording
+from playback.recordings.sqlite.sqlite_recording import SqliteRecording
+
+
+def get_recording_class(metadata):
+    # type: (dict) -> Type[Recording]
+    """
+    Returns the appropriate recording class based on the metadata provided.
+    """
+    recording_type = metadata.get('_recording_type', 'memory') or 'memory'
+
+    if recording_type == "sqlite":
+        recording_class = SqliteRecording
+    elif recording_type == "memory":
+        recording_class = MemoryRecording
+    else:
+        raise Exception('Unsupported recording type {}'.format(recording_type))
+
+    return recording_class

--- a/playback/recordings/memory/memory_recording.py
+++ b/playback/recordings/memory/memory_recording.py
@@ -1,9 +1,68 @@
+import io
+import logging
+from contextlib import contextmanager
+from copy import copy
+from io import BufferedReader
+from zlib import decompress, compress
+
+import six
+from jsonpickle import decode, encode
+
 from playback.exceptions import RecordingKeyError
 from playback.recording import Recording
 from playback.utils.pickle_copy import pickle_copy
 
+from playback.utils.timing_utils import Timed
+
+_logger = logging.getLogger(__name__)
+
 
 class MemoryRecording(Recording):
+    @staticmethod
+    def new(_id=None):
+        return MemoryRecording(_id=_id)
+
+    @staticmethod
+    def from_buffered_reader(recording_id, buffered_reader, recording_metadata):
+        _logger.info(u'Fetching compressed recording using key {}'.format(recording_id))
+        compressed_recording = buffered_reader.read()
+
+        _logger.info(u'Decompressing recording of key {}'.format(recording_id))
+        serialized_data = decompress(compressed_recording)
+
+        _logger.info(u'Decoding recording of key {}'.format(recording_id))
+        full_data = decode(serialized_data)
+
+        # remove metadata from the main recording
+        full_data.pop('_metadata', {})
+
+        _logger.info(u'Returning recording of key {}'.format(recording_id))
+        return MemoryRecording(recording_id, recording_data=full_data, recording_metadata=recording_metadata)
+
+    @contextmanager
+    def as_buffered_reader(self):
+        full_data = copy(self.recording_data)
+
+        # We put meta data also in the full recording
+        full_data['_metadata'] = self.recording_metadata
+
+        with Timed() as timed:
+            encoded_full = encode(full_data, unpicklable=True)
+        encoding_duration = timed.duration
+
+        with Timed() as timed:
+            if six.PY3 and isinstance(encoded_full, str):
+                compressed_full = compress(bytes(encoded_full.encode('utf-8')))
+            else:
+                compressed_full = compress(encoded_full)
+        compression_duration = timed.duration
+
+        recording_size = len(compressed_full)
+
+        _logger.info(u'Encoding recording of key {} took {} seconds'.format(self.id, encoding_duration))
+        _logger.info(u'Compressing recording of key {} took {} seconds'.format(self.id, compression_duration))
+
+        yield BufferedReader(io.BytesIO(compressed_full)), recording_size
 
     def __init__(self, _id=None, recording_data=None, recording_metadata=None):
         """
@@ -17,6 +76,7 @@ class MemoryRecording(Recording):
         super(MemoryRecording, self).__init__(_id=_id)
         self.recording_data = recording_data or {}
         self.recording_metadata = recording_metadata or {}
+        self.recording_metadata['_recording_type'] = 'memory'
 
     def _set_data(self, key, value):
         """

--- a/playback/recordings/sqlite/sqlite_recording.py
+++ b/playback/recordings/sqlite/sqlite_recording.py
@@ -1,0 +1,81 @@
+import io
+import os
+import shutil
+import sqlite3
+import tempfile
+from contextlib import contextmanager, closing
+
+from jsonpickle import encode, decode
+
+from playback.exceptions import RecordingKeyError
+from playback.recording import Recording
+
+
+class SqliteRecording(Recording):
+    """
+    Recording implementation using SQLite as a storage backend. It's more memory-efficient than the in-memory
+    implementation but equally easy to use.
+    """
+    @staticmethod
+    def new(_id=None):
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".db") as db_file:
+            return SqliteRecording(_id=_id, db_file_name=db_file.name)
+
+    @staticmethod
+    def from_buffered_reader(recording_id, buffered_reader, recording_metadata=None):
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".db") as db_file:
+            shutil.copyfileobj(buffered_reader, db_file)
+
+            return SqliteRecording(_id=recording_id, db_file_name=db_file.name, recording_metadata=recording_metadata)
+
+    @contextmanager
+    def as_buffered_reader(self):
+        with io.open(self._db_file_name, "rb") as f:
+            yield f, os.path.getsize(self._db_file_name)
+
+    def __init__(self, db_file_name, _id=None, recording_metadata=None):
+        super(SqliteRecording, self).__init__(_id=_id)
+
+        self._db_file_name = db_file_name
+        self.recording_metadata = recording_metadata or {}
+        self.recording_metadata["_recording_type"] = "sqlite"
+
+        with self._connection() as connection:
+            connection.execute("CREATE TABLE IF NOT EXISTS data (key TEXT PRIMARY KEY, value TEXT)")
+
+    @contextmanager
+    def _connection(self):
+        # Set the isolation level to None to enable autocommit.
+        # Wrapped in closing, because the sqlite3.connect context manager does not close the connection, which
+        # leads to increased memory usage.
+        with closing(sqlite3.connect(self._db_file_name, isolation_level=None)) as connection:
+            connection.row_factory = sqlite3.Row
+            yield connection
+
+    def _set_data(self, key, value):
+        with self._connection() as connection:
+            connection.execute("INSERT OR REPLACE INTO data VALUES (?, ?)", (key, encode(value, unpicklable=True)))
+
+    def get_data(self, key):
+        return self.get_data_direct(key)
+
+    def get_data_direct(self, key):
+        with self._connection() as connection:
+            data = connection.execute("SELECT value FROM data WHERE key=?", (key,))
+            data = data.fetchone()
+            if data is None:
+                raise RecordingKeyError(u'Key \'{}\' not found in recording'.format(key).encode("utf-8"))
+
+        return decode(data["value"])
+
+    def get_all_keys(self):
+        with self._connection() as connection:
+            data = connection.execute("SELECT key FROM data")
+
+            return [row["key"] for row in data]
+
+    def _add_metadata(self, metadata):
+        self.recording_metadata.update(metadata)
+
+    def get_metadata(self):
+        return self.recording_metadata

--- a/tests/recordings/test_recording_factory.py
+++ b/tests/recordings/test_recording_factory.py
@@ -1,0 +1,17 @@
+import unittest
+
+from playback.recordings.factory import get_recording_class
+from playback.recordings.memory.memory_recording import MemoryRecording
+from playback.recordings.sqlite.sqlite_recording import SqliteRecording
+
+
+class TestSqliteRecording(unittest.TestCase):
+    def test_recording_factory(self):
+        self.assertEqual(get_recording_class({'_recording_type': 'sqlite'}), SqliteRecording)
+        self.assertEqual(get_recording_class({'_recording_type': 'memory'}), MemoryRecording)
+        self.assertEqual(get_recording_class({}), MemoryRecording)
+        try:
+            get_recording_class({'_recording_type': 'unknown'})
+            self.fail("An exception should be raised")
+        except Exception as e:
+            self.assertEqual(str(e), "Unsupported recording type unknown")

--- a/tests/recordings/test_sqlite_recording.py
+++ b/tests/recordings/test_sqlite_recording.py
@@ -1,0 +1,88 @@
+from __future__ import absolute_import
+
+import unittest
+
+from playback.recordings.sqlite.sqlite_recording import SqliteRecording
+from playback.exceptions import RecordingKeyError
+
+
+class TestSqliteRecording(unittest.TestCase):
+
+    def test_set_and_get_data_roundtrip(self):
+        rec = SqliteRecording.new()
+
+        payloads = {
+            'int': 42,
+            'float': 3.14,
+            'str': 'hello',
+            'list': [1, 2, 3],
+            'dict': {'a': 1, 'b': [2, 3]},
+        }
+
+        for k, v in payloads.items():
+            rec.set_data(k, v)
+
+        for k, v in payloads.items():
+            self.assertEqual(rec.get_data(k), v)
+
+    def test_get_returns_fresh_copy_each_time(self):
+        rec = SqliteRecording.new()
+        rec.set_data('obj', {'counter': 0})
+
+        first = rec.get_data('obj')
+        second = rec.get_data('obj')
+
+        self.assertEqual(first, {'counter': 0})
+        self.assertEqual(second, {'counter': 0})
+
+        # Mutate first and ensure second remains unaffected (fresh decode on each call)
+        first['counter'] = 99
+        self.assertEqual(second, {'counter': 0})
+        # Re-fetch should still be original
+        self.assertEqual(rec.get_data('obj'), {'counter': 0})
+
+    def test_missing_key_raises_recording_key_error(self):
+        rec = SqliteRecording.new()
+        with self.assertRaises(RecordingKeyError):
+            rec.get_data('does_not_exist')
+
+    def test_get_all_keys_returns_all(self):
+        rec = SqliteRecording.new()
+        rec.set_data('k1', 1)
+        rec.set_data('k2', 2)
+        rec.set_data('k3', 3)
+
+        keys = rec.get_all_keys()
+        self.assertTrue(set(keys) == {'k1', 'k2', 'k3'})
+
+    def test_metadata_add_and_get(self):
+        rec = SqliteRecording.new()
+        rec.add_metadata({'a': 1})
+        rec.add_metadata({'b': 2})
+
+        # Metadata also contains an internal _recording_type field, so we are checking inclusion of the expected keys
+        self.assertLessEqual({'a': 1, 'b': 2}.items(), rec.get_metadata().items())
+
+    def test_new_with_id_preserved(self):
+        rec = SqliteRecording.new('my-id-123')
+        self.assertEqual(rec.id, 'my-id-123')
+
+    def test_from_buffered_reader_loads_from_bytes(self):
+        # Create a recording and persist some data
+        rec1 = SqliteRecording.new()
+        rec1.set_data('foo', {'x': 1})
+
+        # Use the public buffered reader API to clone the DB into a new recording
+        with rec1.as_buffered_reader() as (f, size):
+            self.assertGreater(size, 0)
+            rec2 = SqliteRecording.from_buffered_reader(rec1.id, f, recording_metadata={'meta': True})
+
+        # Validate data and metadata are accessible
+        self.assertEqual(rec2.get_data('foo'), {'x': 1})
+        self.assertEqual(rec2.get_all_keys(), ['foo'])
+        self.assertLessEqual({'meta': True}.items(), rec2.get_metadata().items())
+
+    def test_indirect_setitem_getitem(self):
+        rec = SqliteRecording.new()
+        rec['answer'] = 42
+        self.assertEqual(rec['answer'], 42)

--- a/tests/test_cassettes/async/test_async_tape_cassette_behavior.py
+++ b/tests/test_cassettes/async/test_async_tape_cassette_behavior.py
@@ -38,7 +38,7 @@ class TestAsyncTapeCassette(unittest.TestCase):
         recording = in_memory_cassette.get_recording(_id)
         self.assertEqual(2, recording.get_data('a'))
         self.assertEqual(1, recording.get_data('b'))
-        self.assertEqual({'c': 3, 'd': 4}, recording.get_metadata())
+        self.assertLessEqual(set({'c': 3, 'd': 4}.items()), set(recording.get_metadata().items()))
 
     def test_fetch_recording_operation_raising_errors_read_live_recording_works(self):
         in_memory_cassette = DelayedInMemoryTapeCassette(delay=0.1)
@@ -58,7 +58,7 @@ class TestAsyncTapeCassette(unittest.TestCase):
             recording.add_metadata({'c': 'c'})
             self.assertEqual('a', recording.get_data('a'))
             self.assertSequenceEqual(['a', 'b'], list(recording.get_all_keys()))
-            self.assertEqual({'c': 'c'}, recording.get_metadata())
+            self.assertLessEqual({'c': 'c'}.items(), recording.get_metadata().items())
         finally:
             tape_cassette.close()
 

--- a/tests/test_cassettes/file_based/test_file_based_tape_cassette.py
+++ b/tests/test_cassettes/file_based/test_file_based_tape_cassette.py
@@ -67,7 +67,7 @@ class TestFileBasedTapeCassette(unittest.TestCase):
         fetched_recording = self.cassette.get_recording(recording.id)
         self.assertEqual(recording.id, fetched_recording.id)
 
-        self.assertEqual(metadata, recording.get_metadata())
+        self.assertLessEqual(metadata.items(), recording.get_metadata().items())
         self.assertEqual(recording.get_metadata(), fetched_recording.get_metadata())
 
     def test_fetch_recording_ids_by_category(self):
@@ -109,7 +109,7 @@ class TestFileBasedTapeCassette(unittest.TestCase):
         recording3 = self.cassette.create_new_recording('test_operation2')
         self.cassette.save_recording(recording3)
 
-        assert_items_equal(self, [{'property': False}],
+        assert_items_equal(self, [{'property': False, '_recording_type': 'memory'}],
                            list(self.cassette.iter_recordings_metadata(
                                category='test_operation1',
                                start_date=datetime.utcnow() - timedelta(hours=1),


### PR DESCRIPTION
# The problem

`MemoryRecording` is highly inefficient in terms of memory use. For example, if we're downloading 1GB of data from an API and intercept it with Playback, the intercepted responses will remain in memory, stored in the memory recording, even after the original code no longer needs the data. Worse still, when the recording is saved, it is first deep-copied and then compressed. The results of this compression are also stored in memory. Therefore, for a brief period, we will be holding in memory:
- the original recording
- the deep copy
- the compressed recording
This causes a significant spike in memory usage, which can lead to out-of-memory crashes.

# The solution

Instead of keeping intercepted operations in memory, we can save them to disk using SQLite databases as they are recorded. This approach prevents the recorded data from occupying memory and allows it to be garbage collected. Additionally, the code that saves and retrieves recordings from an S3 bucket was optimized to use streams, ensuring that the recording data is never stored in memory in its entirety.

SQLite was chosen as an underlying data storage because:
- Python has built-in support for it
- SQLite DB is just one file, which makes it easy to store and retrieve from an S3 bucket
- It's very simple to use and it's fast