### PR TITLE
Don't cache intercepted value in AsyncRecording to reduce memory consumption

### DIFF
--- a/playback/recordings/sqlite/sqlite_recording.py
+++ b/playback/recordings/sqlite/sqlite_recording.py
@@ -1,7 +1,6 @@
 import io
 import os
 import shutil
-import sqlite3
 import tempfile
 from contextlib import contextmanager, closing
 
@@ -45,6 +44,8 @@ class SqliteRecording(Recording):
 
     @contextmanager
     def _connection(self):
+        # the sqlite3 module is imported locally only when needed because it can cause issues on some platforms
+        import sqlite3  # pylint: disable=import-outside-toplevel
         # Set the isolation level to None to enable autocommit.
         # Wrapped in closing, because the sqlite3.connect context manager does not close the connection, which
         # leads to increased memory usage.

--- a/playback/tape_recorder.py
+++ b/playback/tape_recorder.py
@@ -148,11 +148,13 @@ class TapeRecorder(object):
         """
         metadata[TapeRecorder.DURATION] = duration
         metadata[TapeRecorder.RECORDED_AT] = str(datetime.utcnow())
-        outputs = TapeRecorder._extract_recorded_output(recording, direct_access=True)
+        # In this method we only need to examine the recording keys, so we are not fetching the full recorded output
+        # which can potentially require thread synchronization if the `AsyncTapeCasset` is being used.
+        output_keys = TapeRecorder._extract_recorded_output_keys(recording)
         # Check if the operation has completed by checking if we have operation output recorded, if not it means
         # the operation method didn't complete and regular exception was not caught
         # (this will happen when BaseException is raised such as KeyboardInterrupt, SystemExit)
-        incomplete = not any(TapeRecorder.OPERATION_OUTPUT_ALIAS in o.key for o in outputs)
+        incomplete = not any(TapeRecorder.OPERATION_OUTPUT_ALIAS in key for key in output_keys)
         metadata[TapeRecorder.INCOMPLETE_RECORDING] = incomplete
         if post_operation_metadata_extractor:
             try:
@@ -903,6 +905,17 @@ class TapeRecorder(object):
         return Playback(playback_outputs, playback_duration, recorded_outputs, recorded_duration, recording)
 
     @staticmethod
+    def _extract_recorded_output_keys(recording):
+        """
+        Extracts the output keys from the given recording
+        :param recording: Recording to extract the output keys from
+        :type recording: playback.tape_cassette.Recording
+        :return: Output keys
+        :rtype: list of basestring
+        """
+        return [key for key in recording.get_all_keys() if key.startswith('output:') and not key.endswith('result')]
+
+    @staticmethod
     def _extract_recorded_output(recording, direct_access=False):
         """
         :param recording:
@@ -912,8 +925,7 @@ class TapeRecorder(object):
         :return: List of output objects
         :rtype: list of Output
         """
-        all_output_keys = [key for key in recording.get_all_keys() if key.startswith('output:') and
-                           not key.endswith('result')]
+        all_output_keys = TapeRecorder._extract_recorded_output_keys(recording)
         return [Output(key, (recording.get_data if not direct_access else recording.get_data_direct)(key))
                 for key in all_output_keys]
 

--- a/tests/test_cassettes/async/test_async_tape_cassette_behavior.py
+++ b/tests/test_cassettes/async/test_async_tape_cassette_behavior.py
@@ -28,11 +28,17 @@ class TestAsyncTapeCassette(unittest.TestCase):
             recording.set_data('a', 2)
             recording.set_data('b', 1)
 
+            self.assertEqual(sorted(recording.get_all_keys()), ['a', 'b'])
+
+            # assert we can read our own writes
+            self.assertEqual(recording.get_data('a'), 2)
+            self.assertEqual(recording.get_data_direct('a'), 2)
+
             if add_error_op:
                 tape_cassette._add_async_operation(error_operation)
 
             tape_cassette.save_recording(recording)
-        self.assertLess(timed.duration, 0.1)
+        self.assertLess(timed.duration, 1)
         tape_cassette.close()
         _id = in_memory_cassette.get_last_recording_id()
         recording = in_memory_cassette.get_recording(_id)


### PR DESCRIPTION
The `AsyncRecording` was storing the intercepted value in memory even though the wrapped recording was also storing this value. This allowed immediate access to the recorded data (without flushing the wrapped recording), but resulted in high memory consumption. Since retrieving data from a recording during the recording operation is very rare, we will now not store the intercepted data in the AsyncRecording, but instead flush the wrapped recording before retrieving data and fetch it directly from there.