### PR TITLE
Run packaging job in Python 3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
 
   deploy:
     docker:
-      - image: circleci/python:2.7.18
+      - image: cimg/python:3.10.13
     steps:
       - checkout
       - run:


### PR DESCRIPTION
# Description

PyPi will begin to reject packages which do not comply with [the PEP 625 name normalisation](https://packaging.python.org/en/latest/specifications/source-distribution-format/#source-distribution-file-name) sooner than later.

More recent versions of `setuptools` automatically convert our package name `playback-studio` to a ZIP file name `playback_studio-<version>.tar.gz` but not the versions from Python 2.

Therefore, this PR makes the packaging job run in Python 3 in the CI, so that we get the intended normalisation behavior.

## Compatibility testing

### Setuptools versions

Some testing gave the following results:

* Python `3.7.9` (max `setuptools==68`) produces `playback-studio-0.3.27.tar.gz`
* Python `3.10.13` (max `setuptools==80.9.0`) produces `playback_studio-0.3.27.tar.gz`

Since the packaging job really does not do much beyond zipping the sources, it's easiest to build the package with Python `3.10.13` or newer.

### Python 2/3 compatibility

Building the package with Python `3.10.13` and installing it under Python `2.7.18` with `pip install playback-studio==0.3.27.dev123` worked fine.