### PR TITLE
Bump jsonpickle modern-version boundary to py3.11 (v0.3.36)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,8 +36,8 @@ setuptools.setup(
     setup_requires=['setuptools>=80.9.0 ; python_version >= "3.10"'],
     install_requires=[
         'parse==1.6.6',
-        'jsonpickle==0.9.4 ; python_version < "3.13"',
-        'jsonpickle>=1, <5 ; python_version >= "3.13"',
+        'jsonpickle==0.9.4 ; python_version < "3.11"',
+        'jsonpickle>=1, <5 ; python_version >= "3.11"',
         'six>=1.15.0',
         'contextlib2==0.6.0',
         'decorator==4.4.2'


### PR DESCRIPTION
## Why

Python 3.11 added a default `object.__getstate__` that returns `None` for `list`/`dict` subclasses with no extra instance state. **jsonpickle 0.9.x** then serializes such objects as `{"py/object": ..., "py/state": null}` with **no `py/seq` / no dict items**, silently dropping their data on decode. Any list/dict subclass that `tape_recorder` round-trips through `jsonpickle.encode` (interception keys, recorded exceptions, recorded values) loses its contents on Python 3.11+ — e.g. PyPy 3.11.

The modern-jsonpickle marker was already applied for `python_version >= "3.13"`. The **correct boundary is 3.11**, where `object.__getstate__` was introduced. PyPy reports `python_version == 3.11` and fell into the broken `< "3.13"` bucket, keeping `jsonpickle==0.9.4`.

## What

- `setup.py`: `jsonpickle` modern marker boundary `3.13` → `3.11`.
- Version bump `0.3.35` → `0.3.36` (`.bumpversion.cfg` + `setup.py`).

## Verification

Full test suite under **PyPy 3.11 + jsonpickle 4.1.2**: 62 passed, 2 failed. The 2 failures (`test_operation_with_input_dict_as_key`, `..._raise_unserializable_error`) are **pre-existing modern-jsonpickle behavior** — they fail identically on CPython 3.13 (which already ships modern jsonpickle with playback), so they are not introduced by this change.

## Context

Unblocks the Optibus/armada py3.11 CI migration: euclid's sdk pins `playback-studio` and applies the same marker fix; once **0.3.36 is published to Fury**, the euclid-side jsonpickle bump can resolve. This fixes armada migration issues #2 (playback), #5 (duty pool persist) and #6 (roster import) — all the same jsonpickle root cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)